### PR TITLE
fix(codec): decode integer overflow

### DIFF
--- a/src/base58.zig
+++ b/src/base58.zig
@@ -91,10 +91,9 @@ pub const Table = struct {
         NoSpaceLeft,
     };
 
-    /// Asserts `decoded.len >= decodedMaxSize(encoded.len)` if comptime or returns an error if runtime and invalid.
+    /// Returns an error if `decoded.len < decodedMaxSize(encoded.len)`.
     pub fn decode(self: Table, decoded: []u8, encoded: []const u8) DecodeError!usize {
-        const is_valid = decoded.len >= decodedMaxSize(encoded.len);
-        if (@inComptime()) std.debug.assert(is_valid) else if (!is_valid) return error.NoSpaceLeft;
+        if (decoded.len < decodedMaxSize(encoded.len)) return error.NoSpaceLeft;
 
         const plus_mul_max = 127 + 255 * 58; // maximum value of `value`, plus the maximum value of `dest[prev_index]` times 58
         const PlusMul = std.math.IntFittingRange(0, plus_mul_max);

--- a/src/base58.zig
+++ b/src/base58.zig
@@ -88,6 +88,7 @@ pub const Table = struct {
     pub const DecodeError = error{
         NonAsciiCharacter,
         InvalidCharacter,
+        NoSpaceLeft,
     };
 
     /// Asserts `decoded.len >= decodedMaxSize(encoded.len)`.
@@ -122,6 +123,7 @@ pub const Table = struct {
         const zero = self.alphabet[0];
         for (encoded) |c| {
             if (c != zero) break;
+            if (index >= decoded.len) return error.NoSpaceLeft;
             decoded[decoded.len - 1 - index] = 0;
             index += 1;
         }
@@ -215,4 +217,10 @@ test "big slice" {
     var data: [10_000]u8 = undefined;
     prng.bytes(&data);
     try testRoundTripFromDecoded(.BITCOIN, &data, null);
+}
+
+test "decode leading zeros exceeding buffer" {
+    const encoded_1111 = "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111";
+    const res = testRoundTripFromEncoded(.BITCOIN, encoded_1111, null);
+    try std.testing.expectError(error.NoSpaceLeft, res);
 }

--- a/src/base58.zig
+++ b/src/base58.zig
@@ -91,9 +91,10 @@ pub const Table = struct {
         NoSpaceLeft,
     };
 
-    /// Asserts `decoded.len >= decodedMaxSize(encoded.len)`.
+    /// Asserts `decoded.len >= decodedMaxSize(encoded.len)` if comptime or returns an error if runtime and invalid.
     pub fn decode(self: Table, decoded: []u8, encoded: []const u8) DecodeError!usize {
-        std.debug.assert(decoded.len >= decodedMaxSize(encoded.len));
+        const is_valid = decoded.len >= decodedMaxSize(encoded.len);
+        if (@inComptime()) std.debug.assert(is_valid) else if (!is_valid) return error.NoSpaceLeft;
 
         const plus_mul_max = 127 + 255 * 58; // maximum value of `value`, plus the maximum value of `dest[prev_index]` times 58
         const PlusMul = std.math.IntFittingRange(0, plus_mul_max);


### PR DESCRIPTION
### Intent

- Fix integer overflow panic occurring in `decode` when an invalid encoded value is provided

### Implementation

- Added a bounds check to `decode`
- Updated the assert at the beginning of `decode` to only execute if comptime, otherwise return an error if the assertion would have failed

### Ramifications

- Currently `decode` will just panic if invalid encoded bytes are provided
- The assert at start of `decode` can SIGTRAP if safety checks are stripped, leading to an unclear failure reason

### Tests

- Added a unit tests to cover the codepath